### PR TITLE
Add Veto X demo talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ You can find my decks [here too](https://speakerdeck.com/leodido).
 
 For questions and engagements feel free to ping me at [@leodido](https://twitter.com/leodido).
 
+<details open><summary>2026</summary>
+<p>
+
+| Date       | Title                                                                                                 |                                            Slides                                            |                    Video                    | Conference                                          | Type |
+| ---------- | ----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------: | :-----------------------------------------: | --------------------------------------------------- | ---- |
+| 2026.03.03 | [Claude Code bypasses its own security, then meets the Ona kernel](https://ona.com/stories/how-claude-code-escapes-its-own-denylist-and-sandbox) | :heavy_multiplication_x: | [Watch](https://www.youtube.com/watch?v=kMoh4tCHyZA) :vhs: | | Demo |
+
+</p>
+</details>
+
 <details open><summary>2022</summary>
 <p>
 

--- a/data.json
+++ b/data.json
@@ -1,5 +1,31 @@
 [
  {
+    "year": "2026",
+    "month": "03",
+    "day": "03",
+    "type": "demo",
+    "title": "Claude Code bypasses its own security, then meets the Ona kernel",
+    "url": "https://ona.com/stories/how-claude-code-escapes-its-own-denylist-and-sandbox",
+    "pitch": "Every major runtime security tool identifies executables by path, not content. AI agents can reason about and bypass path-based restrictions. This demo shows Claude Code bypassing its own denylist and sandbox, then being stopped by [Veto X](https://ona.com/docs/ona/organizations/policies/executable-deny-list), a content-addressable kernel enforcement engine that uses SHA-256 hashing at the BPF LSM layer to identify binaries by content.",
+    "deck": null,
+    "youtube": {
+      "id": "kMoh4tCHyZA",
+      "playlist": "PL-YnLgW35W60wX9lhu6-a8ln4I9yfT1ug"
+    },
+    "repositories": [],
+    "conference": null,
+    "tags": [
+      "kernel",
+      "eBPF",
+      "security",
+      "BPF LSM",
+      "AI agents",
+      "Veto",
+      "execution",
+      "content-addressable"
+    ]
+  },
+  {
     "year": "2022",
     "month": "03",
     "day": "04",


### PR DESCRIPTION
Adds the Veto demo entry to `data.json` and a new 2026 section to `README.md`.

Demo video accompanying the blog post: [How Claude Code escapes its own denylist and sandbox](https://ona.com/stories/how-claude-code-escapes-its-own-denylist-and-sandbox).