### PR TITLE
chore: install git-lfs in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
-# use this Dockerfile to install additional tools you might need, e.g.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# git-lfs is required because slide PDFs are tracked with Git LFS
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends git-lfs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Installs `git-lfs` in the devcontainer. Without it, PDF slide decks (tracked via Git LFS) check out as pointer files instead of actual PDFs, and `git add` stores raw binaries instead of LFS pointers — which is what caused the broken SAVEPOINT in the `wip` branch.